### PR TITLE
Add access to DRI devices

### DIFF
--- a/org.kde.ruqola.json
+++ b/org.kde.ruqola.json
@@ -6,6 +6,7 @@
     "command": "ruqola",
     "rename-icon": "ruqola",
     "finish-args": [
+        "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",


### PR DESCRIPTION
Fixes:
```
libEGL warning: wayland-egl: could not open /dev/dri/renderD128 (No such file or directory)
```

Fixes: https://github.com/flathub/org.kde.ruqola/issues/1